### PR TITLE
[OCR引擎增加]添加适配了PP-OCRv5的PaddleOCR-json插件

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "WechatOCR_umi_plugin"]
 	path = WechatOCR_umi_plugin
 	url = git@github.com:eaeful/WechatOCR_umi_plugin.git
+[submodule "PaddleOCR-json_PP-OCRv5_umi_plugin"]
+	path = PaddleOCR-json_PP-OCRv5_umi_plugin
+	url = git@github.com:OneDongua/PaddleOCR-json_PP-OCRv5_umi_plugin.git


### PR DESCRIPTION
最近使用Umi-OCR的时候发现识别准确率一般，发现PaddleOCR-json插件已经很久没有更新了，于是尝试自己适配
没有在PaddleOCR-json仓库提PR的原因是，我是基于1.4.1稳定版移植的新版PaddleOCR。如果这个更新在您的计划内，我也可以将我的修改应用到PaddleOCR-json的main分支上提交